### PR TITLE
Add support for AVX2 TLSH difference calculations

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+linker = "x86_64-unknown-linux-gnu-gcc"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -98,6 +98,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "ctor"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +172,8 @@ name = "simbiota-tlsh"
 version = "1.0.0"
 dependencies = [
  "clap",
+ "cpufeatures",
+ "ctor",
  "hex",
  "memmap2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,9 +53,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.11"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
+checksum = "3e5a21b8495e732f1b3c364c9949b201ca7bae518c502c80256c96ad79eaf6ac"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.11"
+version = "4.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
+checksum = "8cf2dd12af7a047ad9d6da2b6b249759a22a7abc0f474c1dae1777afa4b21a73"
 dependencies = [
  "anstream",
  "anstyle",
@@ -75,9 +75,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.11"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d029b67f89d30bbb547c89fd5161293c0aec155fc691d7924b64550662db93e"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -99,9 +99,9 @@ checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "51e852e6dc9a5bed1fae92dd2375037bf2b768725bf3be87811edee3249d09ad"
 dependencies = [
  "libc",
 ]
@@ -136,9 +136,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "proc-macro2"
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -176,9 +176,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "simbiota-tlsh"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "clap",
  "cpufeatures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,15 +141,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "memmap2"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,7 +166,6 @@ dependencies = [
  "cpufeatures",
  "ctor",
  "hex",
- "memmap2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ path = "src/bin/cli.rs"
 
 [dependencies]
 clap = { version = "4.5.11", features = ["derive"] }
+cpufeatures = "0.2.12"
+ctor = "0.2.8"
 hex="0.4.3"
 memmap2 = "0.9.4"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,15 @@ keywords = ["tlsh", "similarity-hash", "hash", "locality", "locality-sensitive"]
 name = "tlsh"
 path = "src/bin/cli.rs"
 
+[[bin]]
+name = "speedtest"
+path = "src/bin/speedtest.rs"
+
 [dependencies]
 clap = { version = "4.5.11", features = ["derive"] }
 cpufeatures = "0.2.12"
 ctor = "0.2.8"
 hex="0.4.3"
-memmap2 = "0.9.4"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simbiota-tlsh"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 
 # publishing

--- a/src/bin/speedtest.rs
+++ b/src/bin/speedtest.rs
@@ -1,0 +1,41 @@
+use simbiota_tlsh::TLSH;
+use std::time::Instant;
+
+fn main() {
+    let args = std::env::args().collect::<Vec<_>>();
+    let path = &args[1];
+
+    let mut tlshs = Vec::new();
+    for line in std::fs::read_to_string(path).unwrap().lines() {
+        let hash = TLSH::from_digest(line);
+        tlshs.push(hash);
+    }
+
+    println!("using {} for diffing", simbiota_tlsh::tlsh_diff_mode());
+    let comparisions = tlshs.len().pow(2);
+
+    let thread_count: usize = std::env::var("SPEEDTEST_THREADS")
+        .unwrap_or("1".into())
+        .parse()
+        .unwrap();
+    println!("performing {} comparisions with {} threads", comparisions, thread_count);
+    let start = Instant::now();
+    std::thread::scope(|scope| {
+        for _ in 0..thread_count {
+            scope.spawn(|| {
+                for h1 in &tlshs {
+                    for h2 in &tlshs {
+                        let _diff = TLSH::diff(h1, h2);
+                    }
+                }
+            });
+        }
+    });
+    let comparisions = comparisions * thread_count;
+    let end = start.elapsed();
+    println!("{} comparisions took {:?}", comparisions, end);
+    let secs = end.as_secs_f64();
+    let comparisions = comparisions as f64;
+    let cps = comparisions / secs;
+    println!("speed: {:.2} cmp/s", cps);
+}

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -59,12 +59,17 @@ impl TLSH {
         d
     }
     fn diff_codes(a: &Self, b: &Self) -> u32 {
-        let mut d: u32 = 0;
-        for (ac, bc) in a.codes.into_iter().zip(b.codes) {
-            d += DIFF_CODES[ac as usize][bc as usize];
-        }
-        d
+        crate::vec::tlsh_diff_codes(&a.codes, &b.codes)
     }
+}
+
+
+pub(crate) fn tlsh_diff_codes_lut(a: &[u8;32], b: &[u8; 32]) -> u32 {
+    let mut d: u32 = 0;
+    for (ac, bc) in a.into_iter().zip(b) {
+        d += DIFF_CODES[*ac as usize][*bc as usize];
+    }
+    d 
 }
 
 const DIFF_CODES: [[u32; 256]; 256] = [

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -6,6 +6,7 @@ pub const EFF_BUCKETS: usize = 128;
 ///
 /// A hash object can be converted to and parsed from raw bytes or a digest string.
 #[derive(Copy, Clone, Debug)]
+#[repr(C)]
 pub struct TLSH {
     pub checksum: u8,
     pub lvalue: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod diff;
 mod digest;
 mod hash;
 mod util;
+mod vec;
 
 pub use crate::{
     builder::{ColoredTLSHBuilder, TLSHBuilder, TLSHError},

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod digest;
 mod hash;
 mod util;
 mod vec;
+pub use vec::tlsh_diff_mode;
 
 pub use crate::{
     builder::{ColoredTLSHBuilder, TLSHBuilder, TLSHError},

--- a/src/vec/calc.rs
+++ b/src/vec/calc.rs
@@ -1,0 +1,55 @@
+fn tlsh_diff_f3_64(i: u64, j: u64) -> u32 {
+    let mut res = i ^ j;
+
+    let i0_j1 = (!i) & j;
+    let i1_j0 = i & (!j);
+
+    let even_01 = i0_j1 & 0xAAAAAAAAAAAAAAAA;
+    let odd_01 = (i0_j1 & 0x5555555555555555) << 1;
+    let even_10 = i1_j0 & 0xAAAAAAAAAAAAAAAA;
+    let odd_10 = (i1_j0 & 0x5555555555555555) << 1;
+
+    let mask = (even_01 & odd_10) | (even_10 & odd_01);
+
+    res &= (!mask);
+
+    let odd_dups = res & 0x3333333333333333;
+    let mut three = odd_dups & (odd_dups << 1);
+    let mut six = three | (three << 1);
+    let mut masked_originals = odd_dups & !(six >> 1);
+
+    let mut s1 = six + masked_originals;
+
+    let even_dups = (res >> 2) & 0x3333333333333333;
+    three = even_dups & (even_dups << 1);
+    six = three | (three << 1);
+    masked_originals = even_dups & !(six >> 1);
+
+    s1 += six + masked_originals;
+
+    let mut even = s1 & 0xF0F0F0F0F0F0F0F0;
+    let mut odd = s1 & 0x0F0F0F0F0F0F0F0F;
+    s1 = (even >> 4) + odd;
+
+    even = s1 & 0xFF00FF00FF00FF00;
+    odd = s1 & 0x00FF00FF00FF00FF;
+    s1 = (even >> 8) + odd;
+
+    even = s1 & 0xFFFF0000FFFF0000;
+    odd = s1 & 0x0000FFFF0000FFFF;
+
+    s1 = (even >> 16) + odd;
+
+    even = s1 & 0xFFFFFFFF00000000;
+    odd = s1 & 0x00000000FFFFFFFF;
+
+    ((even >> 32) + odd) as u32
+}
+
+pub(crate) fn tlsh_diff_codes_64(a: &[u8; 32], b: &[u8;32]) -> u32 {
+    let mut d = 0u32;
+    for i in 0..4 {
+        d += tlsh_diff_f3_64(unsafe { *(a.as_ptr().add(i * 8) as *const u64)}, unsafe { *(b.as_ptr().add(i * 8) as *const u64)});
+    }
+    d
+}

--- a/src/vec/calc.rs
+++ b/src/vec/calc.rs
@@ -11,7 +11,7 @@ fn tlsh_diff_f3_64(i: u64, j: u64) -> u32 {
 
     let mask = (even_01 & odd_10) | (even_10 & odd_01);
 
-    res &= (!mask);
+    res &= !mask;
 
     let odd_dups = res & 0x3333333333333333;
     let mut three = odd_dups & (odd_dups << 1);

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -1,0 +1,46 @@
+use std::sync::atomic::Ordering;
+use ctor::ctor;
+use crate::diff;
+
+#[cfg(target_arch = "x86_64")]
+mod x86 {
+    use std::arch::x86_64::_mm256_loadu_si256;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use ctor::ctor;
+
+    cpufeatures::new!(cpuid_avx2, "avx2");
+    pub(crate) static HAS_AVX2: AtomicBool = AtomicBool::new(false);
+    
+    #[ctor]
+    fn init_has_avx2() {
+        let token: cpuid_avx2::InitToken = cpuid_avx2::init();
+        let value = token.get();
+        HAS_AVX2.store(value, Ordering::SeqCst);
+    }
+    
+    pub(crate) fn tlsh_diff_codes_avx2(a: &[u8; 32], b: &[u8; 32]) -> u32 {
+        unsafe {
+            let a = _mm256_loadu_si256(a.as_ptr() as *const _);
+            let b = _mm256_loadu_si256(b.as_ptr() as *const _);
+            avx2::diff_codes_avx2(a,b)
+        }
+    }
+    mod avx2;
+}
+
+type tlsh_diff_codes_fn = fn(a: &[u8; 32], b: &[u8;32]) -> u32;
+static mut TLSH_DIFF_CODES_PTR: tlsh_diff_codes_fn = diff::tlsh_diff_codes_lut;
+
+#[ctor]
+fn init_diff_codes() {
+    #[cfg(target_arch = "x86_64")]
+    if x86::HAS_AVX2.load(Ordering::Relaxed) {
+        unsafe { TLSH_DIFF_CODES_PTR = x86::tlsh_diff_codes_avx2 };
+    }
+}
+
+pub fn tlsh_diff_codes(a: &[u8; 32], b: &[u8; 32]) -> u32 {
+    unsafe {
+        TLSH_DIFF_CODES_PTR(a,b)
+    }
+}

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -1,47 +1,54 @@
-use std::sync::atomic::Ordering;
-use ctor::ctor;
 use crate::diff;
+use ctor::ctor;
+use std::sync::atomic::Ordering;
 
 #[cfg(target_arch = "x86_64")]
 mod x86 {
+    use ctor::ctor;
     use std::arch::x86_64::_mm256_loadu_si256;
     use std::sync::atomic::{AtomicBool, Ordering};
-    use ctor::ctor;
 
     cpufeatures::new!(cpuid_avx2, "avx2");
     pub(crate) static HAS_AVX2: AtomicBool = AtomicBool::new(false);
-    
+
     #[ctor]
     fn init_has_avx2() {
         let token: cpuid_avx2::InitToken = cpuid_avx2::init();
         let value = token.get();
         HAS_AVX2.store(value, Ordering::SeqCst);
     }
-    
+
     pub(crate) fn tlsh_diff_codes_avx2(a: &[u8; 32], b: &[u8; 32]) -> u32 {
         unsafe {
             let a = _mm256_loadu_si256(a.as_ptr() as *const _);
             let b = _mm256_loadu_si256(b.as_ptr() as *const _);
-            avx2::diff_codes_avx2(a,b)
+            avx2::diff_codes_avx2(a, b)
         }
     }
     mod avx2;
 }
 
-type tlsh_diff_codes_fn = fn(a: &[u8; 32], b: &[u8;32]) -> u32;
+type tlsh_diff_codes_fn = fn(a: &[u8; 32], b: &[u8; 32]) -> u32;
 static mut TLSH_DIFF_CODES_PTR: tlsh_diff_codes_fn = diff::tlsh_diff_codes_lut;
+static mut TLSH_DIFF_CODES_MODE: &str = "LUT";
 
 #[ctor]
 fn init_diff_codes() {
     #[cfg(target_arch = "x86_64")]
     if x86::HAS_AVX2.load(Ordering::Relaxed) {
-        unsafe { TLSH_DIFF_CODES_PTR = x86::tlsh_diff_codes_avx2 };
+        unsafe {
+            TLSH_DIFF_CODES_PTR = x86::tlsh_diff_codes_avx2;
+            TLSH_DIFF_CODES_MODE = "avx2";
+        }
     }
 }
 
 #[inline(always)]
+pub fn tlsh_diff_mode() -> &'static str {
+    unsafe { TLSH_DIFF_CODES_MODE }
+}
+
+#[inline(always)]
 pub fn tlsh_diff_codes(a: &[u8; 32], b: &[u8; 32]) -> u32 {
-    unsafe {
-        TLSH_DIFF_CODES_PTR(a,b)
-    }
+    unsafe { TLSH_DIFF_CODES_PTR(a, b) }
 }

--- a/src/vec/mod.rs
+++ b/src/vec/mod.rs
@@ -39,6 +39,7 @@ fn init_diff_codes() {
     }
 }
 
+#[inline(always)]
 pub fn tlsh_diff_codes(a: &[u8; 32], b: &[u8; 32]) -> u32 {
     unsafe {
         TLSH_DIFF_CODES_PTR(a,b)

--- a/src/vec/x86/avx2.rs
+++ b/src/vec/x86/avx2.rs
@@ -5,6 +5,7 @@ use std::arch::x86_64::{
 };
 
 #[inline(always)]
+#[no_mangle]
 pub(crate) fn diff_codes_avx2(i: __m256i, j: __m256i) -> u32 {
     unsafe {
         let mut res = _mm256_xor_si256(i, j);

--- a/src/vec/x86/avx2.rs
+++ b/src/vec/x86/avx2.rs
@@ -1,0 +1,109 @@
+use std::arch::x86_64::{
+    __m256i, _mm256_add_epi32, _mm256_and_si256, _mm256_andnot_si256, _mm256_extracti128_si256,
+    _mm256_or_si256, _mm256_set1_epi32, _mm256_slli_epi32, _mm256_srli_epi32, _mm256_xor_si256,
+    _mm_add_epi32, _mm_extract_epi32,
+};
+
+pub(crate) fn diff_codes_avx2(i: __m256i, j: __m256i) -> u32 {
+    unsafe {
+        let mut res = _mm256_xor_si256(i, j);
+        let i0_j1 = _mm256_andnot_si256(i, j);
+        let i1_j0 = _mm256_andnot_si256(j, i);
+
+        let mask_a = _mm256_set1_epi32(0xAAAAAAAA_u32 as i32);
+        let mask_5 = _mm256_set1_epi32(0x55555555);
+
+        let even_01 = _mm256_and_si256(i0_j1, mask_a);
+        let odd_01 = _mm256_slli_epi32::<1>(_mm256_and_si256(i0_j1, mask_5));
+
+        let even_10 = _mm256_and_si256(i1_j0, mask_a);
+        let odd_10 = _mm256_slli_epi32::<1>(_mm256_and_si256(i1_j0, mask_5));
+
+        //uint32_t mask = (even_01 & odd_10) | (even_10 & odd_01);
+        let mask = _mm256_or_si256(
+            _mm256_and_si256(even_01, odd_10),
+            _mm256_and_si256(even_10, odd_01),
+        );
+
+        //res &= (~mask);
+        res = _mm256_andnot_si256(mask, res);
+
+        //uint32_t odd_dups = res & 0x33333333;
+        let mask3 = _mm256_set1_epi32(0x33333333);
+        let odd_dups = _mm256_and_si256(res, mask3);
+
+        //uint32_t three = odd_dups & (odd_dups << 1);
+        let mut three = _mm256_and_si256(odd_dups, _mm256_slli_epi32::<1>(odd_dups));
+
+        //uint32_t six = three | (three << 1);
+        let mut six = _mm256_or_si256(three, _mm256_slli_epi32::<1>(three));
+
+        //uint32_t masked_originals = odd_dups & ~(six >> 1);
+        let mut masked_originals = _mm256_andnot_si256(_mm256_srli_epi32::<1>(six), odd_dups);
+
+        //uint32_t s1 = six + masked_originals;
+        let mut s1 = _mm256_add_epi32(six, masked_originals);
+
+        //uint32_t even_dups = (res >> 2) & 0x33333333;
+        let even_dups = _mm256_and_si256(_mm256_srli_epi32::<2>(res), mask3);
+
+        //three = even_dups & (even_dups << 1);
+        three = _mm256_and_si256(even_dups, _mm256_slli_epi32::<1>(even_dups));
+
+        //six = three | (three << 1);
+        six = _mm256_or_si256(three, _mm256_slli_epi32::<1>(three));
+
+        //masked_originals = even_dups & ~(six >> 1);
+        masked_originals = _mm256_andnot_si256(_mm256_srli_epi32::<1>(six), even_dups);
+
+        //s1 += six + masked_originals;
+        s1 = _mm256_add_epi32(s1, six);
+        s1 = _mm256_add_epi32(s1, masked_originals);
+
+        let mask_f0f0f0f0 = _mm256_set1_epi32(0xF0F0F0F0_u32 as i32);
+        let mask0f0f0f0f = _mm256_set1_epi32(0x0F0F0F0F);
+
+        let mask_ff00ff00 = _mm256_set1_epi32(0xFF00FF00_u32 as i32);
+        let mask00ff00ff = _mm256_set1_epi32(0x00FF00FF);
+
+        let mask_ffff0000 = _mm256_set1_epi32(0xFFFF0000_u32 as i32);
+        let mask0000ffff = _mm256_set1_epi32(0x0000FFFF);
+
+        //uint32_t even = s1 & 0xF0F0F0F0;
+        let mut even = _mm256_and_si256(s1, mask_f0f0f0f0);
+
+        //uint32_t odd = s1 & 0x0F0F0F0F;
+        let mut odd = _mm256_and_si256(s1, mask0f0f0f0f);
+
+        //s1 = (even >> 4) + odd;
+        s1 = _mm256_add_epi32(_mm256_srli_epi32::<4>(even), odd);
+
+        //even = s1 & 0xFF00FF00;
+        even = _mm256_and_si256(s1, mask_ff00ff00);
+
+        //odd = s1 & 0x00FF00FF;
+        odd = _mm256_and_si256(s1, mask00ff00ff);
+
+        //s1 = (even >> 8) + odd;
+        s1 = _mm256_add_epi32(_mm256_srli_epi32::<8>(even), odd);
+
+        //even = s1 & 0xFFFF0000;
+        even = _mm256_and_si256(s1, mask_ffff0000);
+
+        //odd = s1 & 0x0000FFFF;
+        odd = _mm256_and_si256(s1, mask0000ffff);
+
+        s1 = _mm256_add_epi32(_mm256_srli_epi32::<16>(even), odd);
+
+        let s1_lo_128 = _mm256_extracti128_si256::<0>(s1);
+        let s1_hi_128 = _mm256_extracti128_si256::<1>(s1);
+
+        let su = _mm_add_epi32(s1_lo_128, s1_hi_128);
+
+        let mut s = _mm_extract_epi32::<0>(su);
+        s += _mm_extract_epi32::<1>(su);
+        s += _mm_extract_epi32::<2>(su);
+        s += _mm_extract_epi32::<3>(su);
+        s as u32
+    }
+}

--- a/src/vec/x86/avx2.rs
+++ b/src/vec/x86/avx2.rs
@@ -4,6 +4,7 @@ use std::arch::x86_64::{
     _mm_add_epi32, _mm_extract_epi32,
 };
 
+#[inline(always)]
 pub(crate) fn diff_codes_avx2(i: __m256i, j: __m256i) -> u32 {
     unsafe {
         let mut res = _mm256_xor_si256(i, j);


### PR DESCRIPTION
When available, the library will use a faster, AVX2 based TLSH diff calculation on x86.